### PR TITLE
[Ethan] [Fixes #24788149] More Tandem::Content subclass bug fixin'

### DIFF
--- a/app/models/tandem/content.rb
+++ b/app/models/tandem/content.rb
@@ -36,5 +36,5 @@ module Tandem
   end
 end
 
-require 'image'
-require 'text'
+load 'image.rb'
+load 'text.rb'


### PR DESCRIPTION
Using load instead of require to load subclasses, since require wasn't causing them to be loaded on subsequent requests.

https://www.pivotaltracker.com/story/show/24788149
