### PR TITLE
[Ethan] [Fixes #25482679] Read home bug

### DIFF
--- a/app/controllers/tandem/pages_controller.rb
+++ b/app/controllers/tandem/pages_controller.rb
@@ -7,7 +7,7 @@ module Tandem
     # GET /pages.home.json
     def home
       @page = Page.where(is_default: true).first || Page.first || Page.new
-      authorize!('index', Page)
+      authorize!(:index, Page)
       respond_to do |format|
         format.html { render (@page.template.present? ? @page.template : 'show'), notice: @page.new_record? ? 'No Pages Found.' : '' }
         format.json { render json: @page }

--- a/spec/controllers/tandem/pages_controller_spec.rb
+++ b/spec/controllers/tandem/pages_controller_spec.rb
@@ -72,7 +72,21 @@ module Tandem
       end
     end
 
-    describe "Get home" do
+    describe "GET home" do
+      context "when the user can only read Page" do
+        before(:each) do
+          ability = Object.new
+          ability.extend(CanCan::Ability)
+          ability.can :read, Page
+          controller.stub(:current_ability) { ability }
+        end
+        
+        subject { get :home }
+
+        it { should render_template("tandem/pages/show") }
+        its(:code) { should == '200' }
+      end
+
       context "page without a custom template set" do
         before(:each) { Factory(:tandem_page, is_default: true) }
         subject { get :home }


### PR DESCRIPTION
Reference the CanCan symbolized ability for :index, instead of 'index'.

https://www.pivotaltracker.com/story/show/25482679
