### PR TITLE
[Ethan] Tandem helper bug

### DIFF
--- a/app/controllers/tandem/pages_controller.rb
+++ b/app/controllers/tandem/pages_controller.rb
@@ -6,7 +6,7 @@ module Tandem
     # GET /pages/home
     # GET /pages.home.json
     def home
-      @page = Page.where(is_default: true).first || Page.first || Page.new
+      @page = Page.where(is_default: true).first || Page.first || create_default_page
       authorize!(:index, Page)
       respond_to do |format|
         format.html { render (@page.template.present? ? @page.template : 'show'), notice: @page.new_record? ? 'No Pages Found.' : '' }
@@ -96,6 +96,10 @@ module Tandem
         else
           'application'
       end
+    end
+
+    def create_default_page
+      Page.create!(link_label: 'Sample Page', slug: 'sample', is_default: true)
     end
   end
 end

--- a/lib/tandem/engine.rb
+++ b/lib/tandem/engine.rb
@@ -10,8 +10,14 @@ module Tandem
 
     config.eager_load_paths << File.expand_path("../../../app/models/tandem/content", __FILE__)
 
-    config.to_prepare do
-      ActionController::Base.helper PagesHelper
+    initializer "tandem.include_page_helpers" do |app|
+      ActiveSupport.on_load(:action_controller) do
+        helper ::Tandem::PagesHelper
+      end
+
+      ActiveSupport.on_load(:action_view) do
+        include ::Tandem::PagesHelper
+      end
     end
   end
 

--- a/spec/controllers/tandem/pages_controller_spec.rb
+++ b/spec/controllers/tandem/pages_controller_spec.rb
@@ -101,6 +101,17 @@ module Tandem
         it { should render_template("tandem/pages/custom_template") }
       end
 
+      context "when there are no pages in the database" do
+        it "should create a page" do
+          lambda { get :home }.should change(Page, :count).by(1)
+        end
+
+        it "should create a page marked as default" do
+          get :home
+          Page.where(is_default: true).first.should be_a(Page)
+        end
+      end
+
     end
 
     describe "GET new" do

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -8,11 +8,14 @@
 </head>
 <body>
 
-<%= yield %>
+  <%= tandem_navigation_tag(@page) %>
 
-  <div id="footer">
+  <%= yield %>
+
+  <div>
     <%= link_to 'Custom route', custom_path %>
   </div>
 
+  <%= render "/shared/footer" %>
 </body>
 </html>

--- a/spec/dummy/app/views/shared/_footer.html.slim
+++ b/spec/dummy/app/views/shared/_footer.html.slim
@@ -1,0 +1,2 @@
+footer
+  = tandem_navigation_tag(@page)

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -5,4 +5,6 @@ Rails.application.routes.draw do
   mount Tandem::Engine => "/tandem"
 
   match '/custom_route' => 'pages#index', :as => 'custom'
+
+  root :to => 'tandem/pages#home'
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,11 @@
+FactoryGirl.define do
+  sequence :email do |n|
+    "user#{n}@example.com"
+  end
+  
+  factory :user do
+    email FactoryGirl.generate :email
+    password "secretSanta23$"
+    password_confirmation "secretSanta23$"
+  end
+end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+include Warden::Test::Helpers
+Warden.test_mode!
+
+describe "Users" do
+  let(:user) { Factory(:user) }
+
+  describe "logging in" do
+    it "logs the user in" do
+      visit '/users/sign_in'
+      fill_in "user_email", :with => user.email
+      fill_in "user_password", :with => 'secretSanta23$'
+      click_button "Sign in"
+    end
+  end
+end
+


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/25743221
https://www.pivotaltracker.com/story/show/25735537

When integrating with Flash Card, we noticed cucumber scenarios were failing because tandem_navigation_tag wasn't available on /users/sign_in. Investigating further, I discovered that this only happened on the first request. Colleen and I observed it on the FC app yesterday, but since a refresh solved it, we thought maybe it wasn't a big deal. 

I wasn't able to reproduce this in the tandem dummy app, though, which also uses devise. I tried making sure rails and devise versions were the same, but couldn't get it to occur on that app. Not sure why. I ended up testing the FC app against my local tandem to verify the fix worked. 

Once I got the tandem helpers showing up on the initial request, another bug showed itself. If there aren't any tandem pages in the database, the pages#home action fails even though it was coded as if it would work. Now, we go ahead and create a page for you. I think we'll now be able to get rid of the persisted? checks in a few places in the app as well. Chore'd.
