### PR TITLE
[Ethan] Non tandem page contents

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,17 @@ gem 'slim'
 gem 'cancan'
 gem 'paperclip'
 
+group :assets do
+  gem 'sass-rails',   '~> 3.1.4'
+  gem 'coffee-rails', '~> 3.1.1'
+
+  # See https://github.com/sstephenson/execjs#readme for more supported runtimes
+  # gem 'therubyracer'
+
+  gem 'uglifier', '>= 1.0.3'
+end
+
+
 # Declare any dependencies that are still in development here instead of in
 # your gemspec. These might include edge Rails or gems from your path or
 # Git. Remember to move these dependencies to your gemspec before releasing

--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,12 @@ group :test, :development do
   gem 'guard-livereload'
   gem 'growl_notify'
 
+  gem 'capybara-webkit'
+  gem 'database_cleaner'
+
   gem 'rb-inotify', :require => false
   gem 'rb-fsevent', :require => false
   gem 'rb-fchange', :require => false
+
+  gem 'pry'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,9 @@ GEM
     childprocess (0.2.2)
       ffi (~> 1.0.6)
     cocaine (0.2.1)
+    coffee-rails (3.1.1)
+      coffee-script (>= 2.2.0)
+      railties (~> 3.1.0)
     coffee-script (2.2.0)
       coffee-script-source
       execjs
@@ -203,6 +206,12 @@ GEM
     ruby_core_source (0.1.5)
       archive-tar-minitar (>= 0.5.2)
     rubyzip (0.9.4)
+    sass (3.1.15)
+    sass-rails (3.1.5)
+      actionpack (~> 3.1.0)
+      railties (~> 3.1.0)
+      sass (~> 3.1.10)
+      tilt (~> 1.3.2)
     selenium-webdriver (2.13.0)
       childprocess (>= 0.2.1)
       ffi (~> 1.0.9)
@@ -229,6 +238,9 @@ GEM
       polyglot
       polyglot (>= 0.3.1)
     tzinfo (0.3.31)
+    uglifier (1.2.3)
+      execjs (>= 0.3.0)
+      multi_json (>= 1.0.2)
     warden (1.1.0)
       rack (>= 1.0)
     xpath (0.1.4)
@@ -240,6 +252,7 @@ PLATFORMS
 DEPENDENCIES
   cancan
   capybara-webkit
+  coffee-rails (~> 3.1.1)
   cucumber-rails
   database_cleaner
   devise
@@ -261,6 +274,8 @@ DEPENDENCIES
   rb-inotify
   rspec-rails
   ruby-debug19
+  sass-rails (~> 3.1.4)
   slim
   spork
   tandem!
+  uglifier (>= 1.0.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,11 +52,13 @@ GEM
       rack-test (>= 0.5.4)
       selenium-webdriver (~> 2.0)
       xpath (~> 0.1.4)
-    capybara-webkit (0.7.2)
+    capybara-webkit (0.10.1)
       capybara (>= 1.0.0, < 1.2)
-    childprocess (0.2.2)
+      json
+    childprocess (0.3.1)
       ffi (~> 1.0.6)
     cocaine (0.2.1)
+    coderay (1.0.5)
     coffee-rails (3.1.1)
       coffee-script (>= 2.2.0)
       railties (~> 3.1.0)
@@ -129,7 +131,6 @@ GEM
       railties (~> 3.0)
       thor (~> 0.14)
     json (1.6.5)
-    json_pure (1.6.1)
     launchy (2.0.5)
       addressable (~> 2.2.6)
     linecache19 (0.5.12)
@@ -138,6 +139,7 @@ GEM
       i18n (>= 0.4.0)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
+    method_source (0.7.0)
     mime-types (1.17.2)
     multi_json (1.0.4)
     nokogiri (1.5.0)
@@ -149,6 +151,10 @@ GEM
       mime-types
     pg (0.13.1)
     polyglot (0.3.3)
+    pry (0.9.8.1)
+      coderay (~> 1.0.5)
+      method_source (~> 0.7)
+      slop (>= 2.4.3, < 3)
     rack (1.3.6)
     rack-cache (1.1)
       rack (>= 0.4)
@@ -205,17 +211,17 @@ GEM
       ruby-debug-base19 (>= 0.11.19)
     ruby_core_source (0.1.5)
       archive-tar-minitar (>= 0.5.2)
-    rubyzip (0.9.4)
+    rubyzip (0.9.6.1)
     sass (3.1.15)
     sass-rails (3.1.5)
       actionpack (~> 3.1.0)
       railties (~> 3.1.0)
       sass (~> 3.1.10)
       tilt (~> 1.3.2)
-    selenium-webdriver (2.13.0)
-      childprocess (>= 0.2.1)
-      ffi (~> 1.0.9)
-      json_pure
+    selenium-webdriver (2.20.0)
+      childprocess (>= 0.2.5)
+      ffi (~> 1.0)
+      multi_json (~> 1.0)
       rubyzip
     slim (1.0.4)
       temple (~> 0.3.4)
@@ -225,6 +231,7 @@ GEM
       activesupport (~> 3.0)
       railties (~> 3.0)
       slim (~> 1.0)
+    slop (2.4.3)
     spork (0.9.0)
     sprockets (2.0.3)
       hike (~> 1.2)
@@ -268,6 +275,7 @@ DEPENDENCIES
   launchy
   paperclip
   pg
+  pry
   rails (~> 3.1.3)
   rb-fchange
   rb-fsevent

--- a/History.rdoc
+++ b/History.rdoc
@@ -1,0 +1,2 @@
+0.2
+ * BREAKING CHANGE - tandem_content_tag no longer has a page passed in. Use tandem_content_tag(identifier, type, option = {}, html_options = {}).

--- a/README.rdoc
+++ b/README.rdoc
@@ -19,7 +19,7 @@ on their merry way.
 It's early in the life of Tandem and we have lots in store, but it's something 
 we find useful and hope you will too.
 
-== Getting Started
+== Getting Started / Installation
 
 Has it ever been easier to check off that "CMS functionality" feature story?
 
@@ -42,6 +42,30 @@ This assumes you have a rails app already. If you don't, <tt>rails new tanem_app
     rake db:migrate
 
 5. Start your app and you're ready to go.
+
+    rails s
+
+== Upgrading
+
+Upgrade just like you would any other engine.
+
+1. Update the gem version to the latest version in your gemfile if you specify a version.
+
+    gem 'tandem', '~> 0.2'
+
+2. Install the updated gem
+
+    bundle update tandem
+
+3. Copy any new migrations from tandem
+
+    rake tandem:install:migrations
+
+4. Migrate
+
+    rake db:migrate
+
+5. Enjoy the new tandem goodness.
 
     rails s
 

--- a/app/assets/javascripts/tandem/pages.js.coffee
+++ b/app/assets/javascripts/tandem/pages.js.coffee
@@ -24,8 +24,3 @@ $(document).ready ->
         height: '90%'
         open: true
       return false
-
-window.reload_tandem_content = (resource_id,resource_url) ->
-  $.fn.colorbox.close()
-  resource_id = '#'+resource_id
-  $(resource_id).load resource_url+' '+resource_id

--- a/app/assets/javascripts/tandem/popup.js
+++ b/app/assets/javascripts/tandem/popup.js
@@ -23,18 +23,7 @@ $().ready(function () {
   });
 })
 
-update_image_selection = function(id) {
-  $('#content_image_image_id').val(id);
-  update_current_image();
-}
 
-update_image_gallery = function() {
-  $('#left_image_panel iframe').attr("src", $('#left_image_panel iframe').attr("src"));
-}
-
-update_current_image = function() {
-  $('#selected_image_viewpane').load($('#selected_image_viewpane').attr('src').replace(':id:',$('#content_image_image_id').val()))
-}
 
 $(document).ready (function() {
   $('h3.settings-toggle').live('click', function () {

--- a/app/assets/javascripts/tandem/popup.js
+++ b/app/assets/javascripts/tandem/popup.js
@@ -2,6 +2,7 @@
 // All this logic will automatically be available in application.js.
 //
 //= require jquery
+//= require jquery_ujs
 //= require tandem/wymeditor/jquery.wymeditor.min
 //= require tandem/images
 //= require tandem/vendor/jquery.ui.widget
@@ -9,23 +10,17 @@
 //= require tandem/vendor/jquery-fileupload/jquery.fileupload.js
 
 $().ready(function () {
-  if($('#success_data').length != 0) {
-    resource_id = $('#success_data').attr('resource_id')
-    resource_url = $('#success_data').attr('resource_url')
-    if(typeof(resource_id)=='undefined') {
-      parent.location = resource_url
-    } else {
-      parent.reload_tandem_content(resource_id,resource_url)
-    }
-  }
+  $('form.tandem_content_editor').on('ajax:success', function(event, content, status, jqXHR){
+    $.get(parent.location.href, function(data, status, jqXHR){
+      var content_id = '#' + content.tag;
 
-  $('.wymeditor').wymeditor({
+      $(content_id, parent.document).html( $(content_id, data).html() );
+      parent.$.fn.colorbox.close();
+    });
   });
-})
 
+  $('.wymeditor').wymeditor({ wymPath: '/assets/tandem/wymeditor/' });
 
-
-$(document).ready (function() {
   $('h3.settings-toggle').live('click', function () {
     $('div.advanced-settings').slideToggle('slow');
   });

--- a/app/controllers/tandem/contents_controller.rb
+++ b/app/controllers/tandem/contents_controller.rb
@@ -84,10 +84,8 @@ module Tandem
 
       respond_to do |format|
         if @content.update_attributes(params[param_key])
-          format.html { render action: "success", notice: 'Content was successfully updated.' }
-          format.json { head :ok }
+          format.json { render json: @content }
         else
-          format.html { render action: "edit" }
           format.json { render json: @content.errors, status: :unprocessable_entity }
         end
       end

--- a/app/controllers/tandem/contents_controller.rb
+++ b/app/controllers/tandem/contents_controller.rb
@@ -1,6 +1,6 @@
 module Tandem
   class ContentsController < ::Tandem::ApplicationController
-    load_and_authorize_resource :page, :class => "Tandem::Page"
+    load_and_authorize_resource
     layout 'tandem/popup'
 
 =begin ### default scaffold actions not currently used
@@ -75,16 +75,12 @@ module Tandem
 
     # GET /contents/1/edit
     def edit
-      @content = @page.contents.find(params[:id])
-      authorize_content!
     end
 
     # PUT /contents/1
     # PUT /contents/1.json
     def update
-      @content = @page.contents.find(params[:id])
       param_key = ActiveModel::Naming.param_key(@content)
-      authorize_content!
 
       respond_to do |format|
         if @content.update_attributes(params[param_key])
@@ -95,12 +91,6 @@ module Tandem
           format.json { render json: @content.errors, status: :unprocessable_entity }
         end
       end
-    end
-  
-    private
-
-    def authorize_content!
-      authorize!(params[:action], @content || Content)
     end
   end
 end

--- a/app/controllers/tandem/images_controller.rb
+++ b/app/controllers/tandem/images_controller.rb
@@ -8,7 +8,6 @@ module Tandem
     # GET /images
     # GET /images.json
     def index
-      @update_current_image = params['update_current_image'].present?
       respond_to do |format|
         format.html # index.html.erb
         format.json { render json: @images }
@@ -83,7 +82,7 @@ module Tandem
       @image.destroy
   
       respond_to do |format|
-        format.html { redirect_to images_url(update_current_image: true) }
+        format.html { redirect_to images_url }
         format.json { head :ok }
       end
     end

--- a/app/helpers/tandem/pages_helper.rb
+++ b/app/helpers/tandem/pages_helper.rb
@@ -224,7 +224,7 @@ module Tandem
       end
 
       def using_tandem_abilities
-        controller.instance_variable_set :@current_ability, ::Tandem::Ability.new(current_user)
+        controller.instance_variable_set :@current_ability, ::Tandem::Ability.new(::Tandem::Configuration.current_user)
         yield.tap do
           controller.instance_variable_set :@current_ability, nil
         end

--- a/app/helpers/tandem/pages_helper.rb
+++ b/app/helpers/tandem/pages_helper.rb
@@ -99,7 +99,6 @@ module Tandem
             raise "Rendering behavior not defined for: #{tandem_content.class.name}"
         end
 
-        #didn't use link_to_if here for performance
         content = link_to(content,tandem_content.link_url,{
             id: "tandem_content_link_#{identifier}",
             class: "tandem_content_link",

--- a/app/models/tandem/content.rb
+++ b/app/models/tandem/content.rb
@@ -1,9 +1,7 @@
 module Tandem
   class Content < ActiveRecord::Base
-    belongs_to :page
-
     validates :tag, presence: true
-    validates :page_id, presence: true, uniqueness: {:scope => [:tag, :type]}
+    validates :request_key, presence: true, uniqueness: {:scope => [:tag, :type]}
 
     #enforce abstract class architecture
     validates :type, presence: true, exclusion: ['Tandem::Content']

--- a/app/models/tandem/content/image.rb
+++ b/app/models/tandem/content/image.rb
@@ -3,7 +3,5 @@ module Tandem
     #todo: the following line introduces an artifact field on the other types of Content. For now there is only one other field type, so this down and dirty association is quickest.
     #todo: I've already added a polymorphic field "attachment" that is designed for this same purpose, but is currently not being used for anything, it should be removed as well^^.
     belongs_to :image, class_name: 'Tandem::Image'
-
-    validates :image_id, presence: true
   end
 end

--- a/app/views/tandem/contents/_form.html.slim
+++ b/app/views/tandem/contents/_form.html.slim
@@ -1,6 +1,6 @@
 // This is the form that controls Image upload and Text Editor
 #tandem-editor-wym
-  = form_for [@page, @content], url: page_content_path(@page.id,@content.id), html: {class: 'tandem_content_editor'} do |f|
+  = form_for @content, url: content_path(@content.id), html: {class: 'tandem_content_editor'} do |f|
     -if @content.errors.any?
       #tandem_error_explanation
         h2 = "#{pluralize(@content.errors.count, "error")} prohibited this content from being saved:"

--- a/app/views/tandem/contents/_form.html.slim
+++ b/app/views/tandem/contents/_form.html.slim
@@ -1,6 +1,6 @@
 // This is the form that controls Image upload and Text Editor
 #tandem-editor-wym
-  = form_for @content, url: content_path(@content.id), html: {class: 'tandem_content_editor'} do |f|
+  = form_for @content, url: content_path(@content.id), remote: true, html: {class: 'tandem_content_editor'} do |f|
     -if @content.errors.any?
       #tandem_error_explanation
         h2 = "#{pluralize(@content.errors.count, "error")} prohibited this content from being saved:"

--- a/app/views/tandem/contents/success.html.slim
+++ b/app/views/tandem/contents/success.html.slim
@@ -1,3 +1,0 @@
-p#notice = notice
-
-#success_data style='display:none' resource_url="#{page_path(@page)}" resource_id="#{@content.tag}""

--- a/app/views/tandem/images/index.html.slim
+++ b/app/views/tandem/images/index.html.slim
@@ -7,7 +7,3 @@
           li 
             a.use href="/" Use
             = link_to 'Delete', image, :confirm => 'Are you sure?', :method => :delete, :class => "delete"
-
-
-  - if @update_current_image
-    script parent.update_current_image();

--- a/app/views/tandem/images/new.html.slim
+++ b/app/views/tandem/images/new.html.slim
@@ -2,6 +2,3 @@ h4.tandem-logo
 p#notice = notice
 
 == render 'form'
-
-- if @update_gallery
-  script parent.update_image_gallery();

--- a/app/views/tandem/pages/show.html.slim
+++ b/app/views/tandem/pages/show.html.slim
@@ -6,11 +6,11 @@
   .container_12.row.clearfix
     p#notice = notice
     .grid_12.span12
-      = tandem_image_tag(@page, :default_image)
+      = tandem_image_tag(:default_image)
     .grid_7.span7
-      = tandem_text_tag(@page, :tandem_text_block)
+      = tandem_text_tag(:tandem_text_block)
     .grid_5.span5
-      = tandem_text_tag(@page, :tandem_sidebar)      
+      = tandem_text_tag(:tandem_sidebar)      
 
   - unless @page.persisted?
     | This is the default page content and should tell the user to go create a page

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,9 +9,9 @@ Tandem::Engine.routes.draw do
     collection do
       get :home
     end
-
-    resources :contents, :only => [:edit, :update]
   end
+
+  resources :contents, :only => [:edit, :update]
 
   root :to => 'pages#home'
 end

--- a/db/migrate/30000000000001_add_request_key_to_tandem_contents.rb
+++ b/db/migrate/30000000000001_add_request_key_to_tandem_contents.rb
@@ -1,0 +1,36 @@
+class AddRequestKeyToTandemContents < ActiveRecord::Migration
+  def up
+    add_column :tandem_contents, :request_key, :string
+    
+    Tandem::Content.all.each do |content|
+      page = content.page
+      content.update_attributes!(:request_key => "tandem-pages-#{page.slug}")
+    end
+
+    remove_column :tandem_contents, :page_id
+
+    add_index :tandem_contents, :request_key
+    add_index :tandem_contents, [:request_key, :type, :tag], :unique => true
+  end
+
+  def down
+    add_column :tandem_contents, :page_id, :integer
+
+    Tandem::Content.all.each do |content|
+      if content.request_key =~ /^tandem-pages-.*$/
+        page = Tandem::Page.find_by_slug(content.request_key.gsub(/^tandem-pages-/, ''))
+
+        if page.present?
+          content.update_attributes!(:page_id => page.id)
+        else
+          raise ActiveRecord::IrreversibleMigration
+        end
+      end
+    end
+
+    remove_column :tandem_contents, :request_key
+
+    add_index :tandem_contents, :page_id
+    add_index :tandem_contents, [:page_id, :type, :tag], :unique => true
+  end
+end

--- a/db/migrate/30000000000001_add_request_key_to_tandem_contents.rb
+++ b/db/migrate/30000000000001_add_request_key_to_tandem_contents.rb
@@ -3,10 +3,13 @@ class AddRequestKeyToTandemContents < ActiveRecord::Migration
     add_column :tandem_contents, :request_key, :string
     
     Tandem::Content.all.each do |content|
-      page = content.page
+      page = Tandem::Page.find(content.page_id)
       content.update_attributes!(:request_key => "tandem-pages-#{page.slug}")
     end
 
+    remove_index :tandem_contents, :page_id
+    remove_index :tandem_contents, [:page_id, :type, :tag]
+    
     remove_column :tandem_contents, :page_id
 
     add_index :tandem_contents, :request_key
@@ -28,6 +31,9 @@ class AddRequestKeyToTandemContents < ActiveRecord::Migration
       end
     end
 
+    remove_index :tandem_contents, :request_key
+    remove_index :tandem_contents, [:request_key, :type, :tag]
+    
     remove_column :tandem_contents, :request_key
 
     add_index :tandem_contents, :page_id

--- a/spec/controllers/tandem/contents_controller_spec.rb
+++ b/spec/controllers/tandem/contents_controller_spec.rb
@@ -30,9 +30,8 @@ module Tandem
         # Content. As you add validations to Content, be sure to
         # update the return value of this method accordingly.
         before(:each) do
-          @page = Factory(:tandem_page)
           @factory = "tandem_content_#{sub_type.simple_type}"
-          @content = Factory(@factory, :page => @page)
+          @content = Factory(@factory)
           @param_key = ActiveModel::Naming.param_key(@content)
           @klass = @content.class
         end
@@ -68,7 +67,7 @@ module Tandem
 
         describe "GET edit" do
           it "assigns the requested content as @content" do
-            get :edit, :page_id => @page.id, :id => @content.id
+            get :edit, :id => @content.id
             assigns(:content).should eq(@content)
           end
         end
@@ -122,16 +121,16 @@ module Tandem
               # receives the :update_attributes message with whatever params are
               # submitted in the request.
               @klass.any_instance.should_receive(:update_attributes).with({'these' => 'params'})
-              put :update, :page_id => @page.id, :id => @content.id, @param_key => {'these' => 'params'}
+              put :update, :id => @content.id, @param_key => {'these' => 'params'}
             end
 
             it "assigns the requested content as @content" do
-              put :update, :page_id => @page.id, :id => @content.id, @param_key => valid_attributes
+              put :update, :id => @content.id, @param_key => valid_attributes
               assigns(:content).should eq(@content)
             end
 
             it "renders the 'edit' template" do
-              put :update, :page_id => @page.id, :id => @content.id, @param_key => valid_attributes
+              put :update, :id => @content.id, @param_key => valid_attributes
               response.should render_template("success")
             end
           end
@@ -140,14 +139,14 @@ module Tandem
             it "assigns the content as @content" do
               # Trigger the behavior that occurs when invalid params are submitted
               @klass.any_instance.stub(:save).and_return(false)
-              put :update, :page_id => @page.id, :id => @content.id, @param_key => {}
+              put :update, :id => @content.id, @param_key => {}
               assigns(:content).should eq(@content)
             end
 
             it "re-renders the 'edit' template" do
               # Trigger the behavior that occurs when invalid params are submitted
               @klass.any_instance.stub(:save).and_return(false)
-              put :update, :page_id => @page.id, :id => @content.id, @param_key => {}
+              put :update, :id => @content.id, @param_key => {}
               response.should render_template("edit")
             end
           end

--- a/spec/controllers/tandem/images_controller_spec.rb
+++ b/spec/controllers/tandem/images_controller_spec.rb
@@ -152,7 +152,7 @@ module Tandem
       it "redirects to the images list" do
         image = Factory(:tandem_image)
         delete :destroy, :id => image.id
-        response.should redirect_to(images_path(update_current_image: true))
+        response.should redirect_to(images_path)
       end
     end
 

--- a/spec/dummy/app/assets/javascripts/application.js
+++ b/spec/dummy/app/assets/javascripts/application.js
@@ -7,3 +7,4 @@
 //= require jquery
 //= require jquery_ujs
 //= require_tree .
+//= require tandem

--- a/spec/dummy/app/assets/javascripts/widgets.js
+++ b/spec/dummy/app/assets/javascripts/widgets.js
@@ -1,0 +1,2 @@
+// Place all the behaviors and hooks related to the matching controller here.
+// All this logic will automatically be available in application.js.

--- a/spec/dummy/app/assets/stylesheets/application.css
+++ b/spec/dummy/app/assets/stylesheets/application.css
@@ -4,4 +4,5 @@
  * the top of the compiled file, but it's generally better to create a new file per style scope.
  *= require_self
  *= require_tree . 
+ *= require tandem
 */

--- a/spec/dummy/app/assets/stylesheets/scaffold.css
+++ b/spec/dummy/app/assets/stylesheets/scaffold.css
@@ -1,0 +1,56 @@
+body { background-color: #fff; color: #333; }
+
+body, p, ol, ul, td {
+  font-family: verdana, arial, helvetica, sans-serif;
+  font-size:   13px;
+  line-height: 18px;
+}
+
+pre {
+  background-color: #eee;
+  padding: 10px;
+  font-size: 11px;
+}
+
+a { color: #000; }
+a:visited { color: #666; }
+a:hover { color: #fff; background-color:#000; }
+
+div.field, div.actions {
+  margin-bottom: 10px;
+}
+
+#notice {
+  color: green;
+}
+
+.field_with_errors {
+  padding: 2px;
+  background-color: red;
+  display: table;
+}
+
+#error_explanation {
+  width: 450px;
+  border: 2px solid red;
+  padding: 7px;
+  padding-bottom: 0;
+  margin-bottom: 20px;
+  background-color: #f0f0f0;
+}
+
+#error_explanation h2 {
+  text-align: left;
+  font-weight: bold;
+  padding: 5px 5px 5px 15px;
+  font-size: 12px;
+  margin: -7px;
+  margin-bottom: 0px;
+  background-color: #c00;
+  color: #fff;
+}
+
+#error_explanation ul li {
+  font-size: 12px;
+  list-style: square;
+}

--- a/spec/dummy/app/assets/stylesheets/widgets.css
+++ b/spec/dummy/app/assets/stylesheets/widgets.css
@@ -1,0 +1,4 @@
+/*
+  Place all the styles related to the matching controller here.
+  They will automatically be included in application.css.
+*/

--- a/spec/dummy/app/controllers/widgets_controller.rb
+++ b/spec/dummy/app/controllers/widgets_controller.rb
@@ -1,0 +1,83 @@
+class WidgetsController < ApplicationController
+  # GET /widgets
+  # GET /widgets.json
+  def index
+    @widgets = Widget.all
+
+    respond_to do |format|
+      format.html # index.html.erb
+      format.json { render json: @widgets }
+    end
+  end
+
+  # GET /widgets/1
+  # GET /widgets/1.json
+  def show
+    @widget = Widget.find(params[:id])
+
+    respond_to do |format|
+      format.html # show.html.erb
+      format.json { render json: @widget }
+    end
+  end
+
+  # GET /widgets/new
+  # GET /widgets/new.json
+  def new
+    @widget = Widget.new
+
+    respond_to do |format|
+      format.html # new.html.erb
+      format.json { render json: @widget }
+    end
+  end
+
+  # GET /widgets/1/edit
+  def edit
+    @widget = Widget.find(params[:id])
+  end
+
+  # POST /widgets
+  # POST /widgets.json
+  def create
+    @widget = Widget.new(params[:widget])
+
+    respond_to do |format|
+      if @widget.save
+        format.html { redirect_to @widget, notice: 'Widget was successfully created.' }
+        format.json { render json: @widget, status: :created, location: @widget }
+      else
+        format.html { render action: "new" }
+        format.json { render json: @widget.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PUT /widgets/1
+  # PUT /widgets/1.json
+  def update
+    @widget = Widget.find(params[:id])
+
+    respond_to do |format|
+      if @widget.update_attributes(params[:widget])
+        format.html { redirect_to @widget, notice: 'Widget was successfully updated.' }
+        format.json { head :ok }
+      else
+        format.html { render action: "edit" }
+        format.json { render json: @widget.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /widgets/1
+  # DELETE /widgets/1.json
+  def destroy
+    @widget = Widget.find(params[:id])
+    @widget.destroy
+
+    respond_to do |format|
+      format.html { redirect_to widgets_url }
+      format.json { head :ok }
+    end
+  end
+end

--- a/spec/dummy/app/helpers/widgets_helper.rb
+++ b/spec/dummy/app/helpers/widgets_helper.rb
@@ -1,0 +1,2 @@
+module WidgetsHelper
+end

--- a/spec/dummy/app/models/widget.rb
+++ b/spec/dummy/app/models/widget.rb
@@ -1,0 +1,2 @@
+class Widget < ActiveRecord::Base
+end

--- a/spec/dummy/app/views/widgets/_form.html.erb
+++ b/spec/dummy/app/views/widgets/_form.html.erb
@@ -1,0 +1,21 @@
+<%= form_for(@widget) do |f| %>
+  <% if @widget.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(@widget.errors.count, "error") %> prohibited this widget from being saved:</h2>
+
+      <ul>
+      <% @widget.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= f.label :name %><br />
+    <%= f.text_field :name %>
+  </div>
+  <div class="actions">
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/spec/dummy/app/views/widgets/edit.html.erb
+++ b/spec/dummy/app/views/widgets/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing widget</h1>
+
+<%= render 'form' %>
+
+<%= link_to 'Show', @widget %> |
+<%= link_to 'Back', widgets_path %>

--- a/spec/dummy/app/views/widgets/index.html.erb
+++ b/spec/dummy/app/views/widgets/index.html.erb
@@ -1,0 +1,23 @@
+<h1>Listing widgets</h1>
+
+<table>
+  <tr>
+    <th>Name</th>
+    <th></th>
+    <th></th>
+    <th></th>
+  </tr>
+
+<% @widgets.each do |widget| %>
+  <tr>
+    <td><%= widget.name %></td>
+    <td><%= link_to 'Show', widget %></td>
+    <td><%= link_to 'Edit', edit_widget_path(widget) %></td>
+    <td><%= link_to 'Destroy', widget, confirm: 'Are you sure?', method: :delete %></td>
+  </tr>
+<% end %>
+</table>
+
+<br />
+
+<%= link_to 'New Widget', new_widget_path %>

--- a/spec/dummy/app/views/widgets/index.html.erb
+++ b/spec/dummy/app/views/widgets/index.html.erb
@@ -20,4 +20,7 @@
 
 <br />
 
+<%= tandem_text_tag(:widget_blurb) %>
+<%= tandem_navigation_tag(@page) %>
+
 <%= link_to 'New Widget', new_widget_path %>

--- a/spec/dummy/app/views/widgets/new.html.erb
+++ b/spec/dummy/app/views/widgets/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New widget</h1>
+
+<%= render 'form' %>
+
+<%= link_to 'Back', widgets_path %>

--- a/spec/dummy/app/views/widgets/show.html.erb
+++ b/spec/dummy/app/views/widgets/show.html.erb
@@ -1,0 +1,10 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <b>Name:</b>
+  <%= @widget.name %>
+</p>
+
+
+<%= link_to 'Edit', edit_widget_path(@widget) %> |
+<%= link_to 'Back', widgets_path %>

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
 
+  mount Tandem::Engine => "/"
+
   resources :widgets
 
   devise_for :users

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
 
+  resources :widgets
+
   devise_for :users
 
   mount Tandem::Engine => "/tandem"

--- a/spec/dummy/db/migrate/20120228183614_create_widgets.rb
+++ b/spec/dummy/db/migrate/20120228183614_create_widgets.rb
@@ -1,0 +1,9 @@
+class CreateWidgets < ActiveRecord::Migration
+  def change
+    create_table :widgets do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/dummy/db/migrate/20120228202448_create_tandem_pages.rb
+++ b/spec/dummy/db/migrate/20120228202448_create_tandem_pages.rb
@@ -1,0 +1,20 @@
+class CreateTandemPages < ActiveRecord::Migration
+  def change
+    create_table :tandem_pages do |t|
+      t.integer :parent_id
+      t.string :title
+      t.string :page_label
+      t.string :link_label, :null => false
+      t.string :layout
+      t.string :template
+      t.string :keywords
+      t.string :description
+      t.string :slug, :null => false
+      t.boolean :is_default, :default => false, :null => false
+
+      t.timestamps
+    end
+
+    add_index :tandem_pages, :parent_id
+  end
+end

--- a/spec/dummy/db/migrate/20120228202449_create_tandem_contents.rb
+++ b/spec/dummy/db/migrate/20120228202449_create_tandem_contents.rb
@@ -1,0 +1,21 @@
+class CreateTandemContents < ActiveRecord::Migration
+  def change
+    create_table :tandem_contents do |t|
+      t.integer :page_id, :null => false
+      t.string :type, :null => false
+      t.string :tag, :null => false
+      t.text :content
+      t.text :details
+      t.string :link_url
+      t.string :link_target
+      t.integer :attachment_id
+      t.string :attachment_type, :default => "Tandem::Image"
+      t.integer :image_id
+
+      t.timestamps
+    end
+
+    add_index :tandem_contents, :page_id
+    add_index :tandem_contents, [:page_id, :type, :tag], :unique => true
+  end
+end

--- a/spec/dummy/db/migrate/20120228202450_create_tandem_images.rb
+++ b/spec/dummy/db/migrate/20120228202450_create_tandem_images.rb
@@ -1,0 +1,12 @@
+class CreateTandemImages < ActiveRecord::Migration
+  def change
+    create_table :tandem_images do |t|
+      t.string :resource_file_name
+      t.string :resource_content_type
+      t.integer :resource_file_size
+      t.datetime :resource_updated_at
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/dummy/db/migrate/20120228202451_create_default_page.rb
+++ b/spec/dummy/db/migrate/20120228202451_create_default_page.rb
@@ -1,0 +1,10 @@
+#NOTE:: The timestamp for the this file is set way into the future so that it is always the last migration run
+class CreateDefaultPage < ActiveRecord::Migration
+  def up
+    Tandem::Page.new(link_label: 'Sample Page', slug: 'sample').save!
+  end
+
+  def down
+    Tandem::Page.delete_all
+  end
+end

--- a/spec/dummy/db/migrate/20120229023256_add_request_key_to_tandem_contents.rb
+++ b/spec/dummy/db/migrate/20120229023256_add_request_key_to_tandem_contents.rb
@@ -1,0 +1,36 @@
+class AddRequestKeyToTandemContents < ActiveRecord::Migration
+  def up
+    add_column :tandem_contents, :request_key, :string
+    
+    Tandem::Content.all.each do |content|
+      page = content.page
+      content.update_attributes!(:request_key => "tandem-pages-#{page.slug}")
+    end
+
+    remove_column :tandem_contents, :page_id
+
+    add_index :tandem_contents, :request_key
+    add_index :tandem_contents, [:request_key, :type, :tag], :unique => true
+  end
+
+  def down
+    add_column :tandem_contents, :page_id, :integer
+
+    Tandem::Content.all.each do |content|
+      if content.request_key =~ /^tandem-pages-.*$/
+        page = Tandem::Page.find_by_slug(content.request_key.gsub(/^tandem-pages-/, ''))
+
+        if page.present?
+          content.update_attributes!(:page_id => page.id)
+        else
+          raise ActiveRecord::IrreversibleMigration
+        end
+      end
+    end
+
+    remove_column :tandem_contents, :request_key
+
+    add_index :tandem_contents, :page_id
+    add_index :tandem_contents, [:page_id, :type, :tag], :unique => true
+  end
+end

--- a/spec/dummy/db/migrate/20120301201442_add_request_key_to_tandem_contents.rb
+++ b/spec/dummy/db/migrate/20120301201442_add_request_key_to_tandem_contents.rb
@@ -3,10 +3,13 @@ class AddRequestKeyToTandemContents < ActiveRecord::Migration
     add_column :tandem_contents, :request_key, :string
     
     Tandem::Content.all.each do |content|
-      page = content.page
+      page = Tandem::Page.find(content.page_id)
       content.update_attributes!(:request_key => "tandem-pages-#{page.slug}")
     end
 
+    remove_index :tandem_contents, :page_id
+    remove_index :tandem_contents, [:page_id, :type, :tag]
+    
     remove_column :tandem_contents, :page_id
 
     add_index :tandem_contents, :request_key
@@ -28,6 +31,9 @@ class AddRequestKeyToTandemContents < ActiveRecord::Migration
       end
     end
 
+    remove_index :tandem_contents, :request_key
+    remove_index :tandem_contents, [:request_key, :type, :tag]
+    
     remove_column :tandem_contents, :request_key
 
     add_index :tandem_contents, :page_id

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 30000000000000) do
+ActiveRecord::Schema.define(:version => 20120228202451) do
 
   create_table "tandem_contents", :force => true do |t|
     t.integer  "page_id",                                      :null => false

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120229023256) do
+ActiveRecord::Schema.define(:version => 20120301201442) do
 
   create_table "tandem_contents", :force => true do |t|
     t.string   "type",                                         :null => false

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -75,4 +75,10 @@ ActiveRecord::Schema.define(:version => 30000000000000) do
   add_index "users", ["email"], :name => "index_users_on_email", :unique => true
   add_index "users", ["reset_password_token"], :name => "index_users_on_reset_password_token", :unique => true
 
+  create_table "widgets", :force => true do |t|
+    t.string   "name"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,10 +11,9 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120228202451) do
+ActiveRecord::Schema.define(:version => 20120229023256) do
 
   create_table "tandem_contents", :force => true do |t|
-    t.integer  "page_id",                                      :null => false
     t.string   "type",                                         :null => false
     t.string   "tag",                                          :null => false
     t.text     "content"
@@ -26,10 +25,11 @@ ActiveRecord::Schema.define(:version => 20120228202451) do
     t.integer  "image_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "request_key"
   end
 
-  add_index "tandem_contents", ["page_id", "type", "tag"], :name => "index_tandem_contents_on_page_id_and_type_and_tag", :unique => true
-  add_index "tandem_contents", ["page_id"], :name => "index_tandem_contents_on_page_id"
+  add_index "tandem_contents", ["request_key", "type", "tag"], :name => "index_tandem_contents_on_request_key_and_type_and_tag", :unique => true
+  add_index "tandem_contents", ["request_key"], :name => "index_tandem_contents_on_request_key"
 
   create_table "tandem_images", :force => true do |t|
     t.string   "resource_file_name"

--- a/spec/factories/tandem/contents.rb
+++ b/spec/factories/tandem/contents.rb
@@ -2,8 +2,8 @@
 
 FactoryGirl.define do
   factory :tandem_content do
-    association :page, :factory => :tandem_page
-    tag "sample_tag"
+    request_key 'tandem-pages-sample'
+    tag "sample-tag"
     link_url "http://www.google.com"
     link_target "_blank"
   end

--- a/spec/factories/tandem/pages.rb
+++ b/spec/factories/tandem/pages.rb
@@ -4,9 +4,11 @@ FactoryGirl.define do
   sequence :link_label do |n|
     "link label #{n}"
   end
+
   sequence :slug do |n|
     "slug_#{n}"
   end
+
   factory :tandem_page, :class => Tandem::Page do
     title "value for title"
     page_label "value for page label"

--- a/spec/helpers/tandem/pages_helper_spec.rb
+++ b/spec/helpers/tandem/pages_helper_spec.rb
@@ -12,6 +12,10 @@ module Tandem
     end
 
     describe "tandem_content_tag" do 
+      before(:each) do
+        helper.stub(:current_user) { Factory.stub(:user) }
+      end
+
       context "rendering text content" do
         let(:content) { Factory(:tandem_content_text) }
 

--- a/spec/models/tandem/content/image_spec.rb
+++ b/spec/models/tandem/content/image_spec.rb
@@ -3,20 +3,8 @@ module Tandem
   require 'spec_helper'
 
   describe Content::Image do
-    before(:each) do
-      @valid_attributes = {
-        :page_id => 1,
-        :tag => 'value for tag',
-        :content => 'value for content',
-        :link_url => 'value for link url',
-        :link_target => '_blank',
-        :image_id => 1
-      }
-    end
-
     it "should create a new instance given valid attributes" do
-      Content::Image.create!(@valid_attributes)
+      Content::Image.create!(Factory.attributes_for(:tandem_content_image))
     end
-
   end
 end

--- a/spec/models/tandem/content/text_spec.rb
+++ b/spec/models/tandem/content/text_spec.rb
@@ -3,18 +3,8 @@ module Tandem
   require 'spec_helper'
 
   describe Content::Text do
-    before(:each) do
-      @valid_attributes = {
-        :page_id => 1,
-        :tag => 'value for tag',
-        :content => 'value for content',
-        :link_url => 'value for link url',
-        :link_target => '_blank'
-      }
-    end
-
     it "should create a new instance given valid attributes" do
-      Content::Text.create!(@valid_attributes)
+      Content::Text.create!(Factory.attributes_for(:tandem_content_text))
     end
 
   end

--- a/spec/models/tandem/content_spec.rb
+++ b/spec/models/tandem/content_spec.rb
@@ -3,11 +3,5 @@ module Tandem
   require 'spec_helper'
 
   describe Content do
-    describe 'associations' do
-      it 'should belong to a tandem_page' do
-        Content.reflect_on_association(:page).should_not be_nil
-        Content.reflect_on_association(:page).macro.should eql(:belongs_to)
-      end
-    end
   end
 end

--- a/spec/requests/contents_spec.rb
+++ b/spec/requests/contents_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe "Tandem Content on non-tandem pages" do
+  describe "get /widgets" do
+    it "renders the widgets index and creates a tandem_content item called :widget_blurb" do
+      get '/widgets'
+    end
+  end
+end
+

--- a/spec/requests/contents_spec.rb
+++ b/spec/requests/contents_spec.rb
@@ -1,5 +1,29 @@
 require 'spec_helper'
 
+describe "Editing" do
+  describe "text content" do
+    it "changes the content", :js => true do
+      visit root_path
+
+      page.execute_script("$('#tandem_toolbar_tandem_text_block').show()") #simulate hover
+      click_link 'tandem_edit_link_tandem_text_block'
+
+      sleep 1 #wait for iframe to load
+      iframe_name = page.evaluate_script("$('iframe.cboxIframe').attr('name');")
+
+      within_frame iframe_name do
+        page.execute_script("jQuery.wymeditors(0).html('<p>I love tandem!</p>');")
+        #fill_in 'content_text_content', :with => 'I love tandem!'
+        click_button 'Save Your Changes'
+      end
+
+      within '#tandem_content_text_tandem_text_block' do
+        page.should have_content('I love tandem!')
+      end
+    end
+  end
+end
+
 describe "Tandem Content on non-tandem pages" do
   describe "get /widgets" do
     it "renders the widgets index and creates a tandem_content item called :widget_blurb" do

--- a/spec/requests/contents_spec.rb
+++ b/spec/requests/contents_spec.rb
@@ -1,21 +1,12 @@
 require 'spec_helper'
 
 describe "Editing" do
+  include RequestHelpers::GeneralHelpers
+
   describe "text content" do
     it "changes the content", :js => true do
       visit root_path
-
-      page.execute_script("$('#tandem_toolbar_tandem_text_block').show()") #simulate hover
-      click_link 'tandem_edit_link_tandem_text_block'
-
-      sleep 1 #wait for iframe to load
-      iframe_name = page.evaluate_script("$('iframe.cboxIframe').attr('name');")
-
-      within_frame iframe_name do
-        page.execute_script("jQuery.wymeditors(0).html('<p>I love tandem!</p>');")
-        #fill_in 'content_text_content', :with => 'I love tandem!'
-        click_button 'Save Your Changes'
-      end
+      edit_tandem_text_content(:tandem_text_block, 'I love tandem!')
 
       within '#tandem_content_text_tandem_text_block' do
         page.should have_content('I love tandem!')

--- a/spec/routing/tandem/contents_routing_spec.rb
+++ b/spec/routing/tandem/contents_routing_spec.rb
@@ -29,11 +29,11 @@ module Tandem
 =end
 
       it "routes to #edit" do
-        get("/pages/1/contents/1/edit").should route_to("tandem/contents#edit", :page_id => "1", :id => "1")
+        get("contents/1/edit").should route_to("tandem/contents#edit", :id => "1")
       end
 
       it "routes to #update" do
-        put("/pages/1/contents/1").should route_to("tandem/contents#update", :page_id => "1", :id => "1")
+        put("contents/1").should route_to("tandem/contents#update", :id => "1")
       end
 
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,10 @@ Spork.prefork do
   require 'rspec/rails'
   require 'factory_girl'
   require 'database_cleaner'
+  require 'capybara-webkit'
+  require 'capybara/rspec'
+
+  Capybara.javascript_driver = :webkit
 
   ENGINE_RAILS_ROOT=File.join(File.dirname(__FILE__), '../')
 

--- a/spec/support/request_helpers/general_helpers.rb
+++ b/spec/support/request_helpers/general_helpers.rb
@@ -1,0 +1,16 @@
+module RequestHelpers
+  module GeneralHelpers
+    def edit_tandem_text_content(identifier, new_text)
+      page.execute_script("$('#tandem_toolbar_#{identifier}').show()") #simulate hover
+      click_link "tandem_edit_link_#{identifier}"
+
+      sleep 1 #wait for iframe to load
+      iframe_name = page.evaluate_script("$('iframe.cboxIframe').attr('name');")
+
+      within_frame iframe_name do
+        page.execute_script("jQuery.wymeditors(0).html('<p>#{new_text}</p>');")
+        click_button 'Save Your Changes'
+      end
+    end
+  end
+end

--- a/spec/views/tandem/contents/edit.html.slim_spec.rb
+++ b/spec/views/tandem/contents/edit.html.slim_spec.rb
@@ -5,7 +5,6 @@ module Tandem
     include SharedSpecHelpers
 
     before(:each) do
-      @page = assign(:page, Factory(:tandem_page))
       stub_all_view_helpers
     end
 
@@ -18,7 +17,7 @@ module Tandem
         render
 
         # Run the generator again with the --webrat flag if you want to use webrat matchers
-        assert_select "form", :action => page_content_path(@page.id,@content.id), :method => "post" do
+        assert_select "form", :action => content_path(@content.id), :method => "post" do
           assert_select "textarea#content_text_content", :name => "content[content]"
           assert_select "input#content_text_link_url", :name => "content[link_url]"
           assert_select "input#content_text_link_target", :name => "content[link_target]"
@@ -35,7 +34,7 @@ module Tandem
         render
 
         # Run the generator again with the --webrat flag if you want to use webrat matchers
-        assert_select "form", :action => page_content_path(@page.id,@content.id), :method => "post" do
+        assert_select "form", :action => content_path(@content.id), :method => "post" do
           assert_select "input#content_image_link_url", :name => "content[link_url]"
           assert_select "input#content_image_link_target", :name => "content[link_target]"
         end


### PR DESCRIPTION
No longer scope tandem contents by page. Instead, use the request parameters. This allows us to place tandem content on any page, not just tandem pages.

Also brought in some capyabara-webkit for a request spec that actually exercises the complete flow of editing content.
