### PR TITLE
[Ethan] Update current_user_proc to pass along the request

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -122,8 +122,8 @@ authentication and authorization.
 
 1. Tell Tandem how to find the current_user
 
-    Tandem::Configuration.current_user_proc {
-      User.find(session['user_id']) unless session['user_id'].blank?
+    Tandem::Configuration.current_user_proc { |request|
+      User.find(request.session['user_id']) unless request.session['user_id'].blank?
     }
 
 2. Define what each user can do using CanCan

--- a/app/controllers/tandem/application_controller.rb
+++ b/app/controllers/tandem/application_controller.rb
@@ -6,7 +6,9 @@ module Tandem
       redirect_to (Configuration::unauthorized_path || root_url) , :alert => exception.message
     end
 
-    define_method :current_user, Configuration.current_user
+    def current_user
+      Configuration.current_user.call(request)
+    end
 
     private
 

--- a/app/helpers/tandem/pages_helper.rb
+++ b/app/helpers/tandem/pages_helper.rb
@@ -230,7 +230,7 @@ module Tandem
       end
 
       def using_tandem_abilities
-        controller.instance_variable_set :@current_ability, ::Tandem::Ability.new(::Tandem::Configuration.current_user)
+        controller.instance_variable_set :@current_ability, ::Tandem::Ability.new(::Tandem::Configuration.current_user.call(request))
         yield.tap do
           controller.instance_variable_set :@current_ability, nil
         end

--- a/lib/generators/templates/initializer.rb
+++ b/lib/generators/templates/initializer.rb
@@ -1,7 +1,15 @@
-Tandem::Configuration.current_user_proc {
+Tandem::Configuration.current_user_proc { |request|
   # Uncomment and/or modify the following line once your project has a user model to
-  # derive abilities from
-  # User.find(session['user_id']) unless session['user_id'].blank?
+  # derive abilities from.
+  #
+  # The request is passed in so you can access it directly to specify what the current
+  # user is, regardless of the context, e.g. main app or Tandem, the proc is called from.
+  #
+  # User.find(request.session['user_id']) unless request.session['user_id'].blank?
+  #
+  # Or, for devise:
+  #
+  # request.env['warden'].authenticate(:scope => :user)
 }
 Tandem::Configuration.user_abilities_proc { |user|
   # Define abilities for the passed in user here. For example:

--- a/spec/dummy/config/initializers/tandem.rb
+++ b/spec/dummy/config/initializers/tandem.rb
@@ -2,8 +2,8 @@ require File.expand_path('../../../../../lib/generators/templates/initializer.rb
 
 module Tandem
   #override the default configuration
-  Configuration.current_user_proc {
-    User.find(session['user_id']) unless session['user_id'].blank?
+  Configuration.current_user_proc { |request|
+    User.find(request.session['user_id']) unless request.session['user_id'].blank?
   }
 end
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/26038811

Some apps need to determine current_user based on the request, so it can be determined regardless of context, e.g. main app vs. tandem
