### PR TITLE
[Ethan] [Fixes #26331775] URL Helper proxy with 0 arguments fix.

### DIFF
--- a/app/helpers/tandem/application_helper.rb
+++ b/app/helpers/tandem/application_helper.rb
@@ -3,6 +3,7 @@ module Tandem
     def self.included(base)
       main_app_url_helpers.each do |helper|
         base.send(:define_method, helper) do |*arguments|
+          arguments = nil if arguments.empty?
           main_app.send(helper, arguments)
         end
       end

--- a/spec/helpers/tandem/application_helper_spec.rb
+++ b/spec/helpers/tandem/application_helper_spec.rb
@@ -16,5 +16,18 @@ module Tandem
         end
       end
     end
+
+    describe 'proxied url helpers' do
+      context 'calling a main app url helper with 0 arguments' do
+        subject { helper.new_widget_path }
+        it { should == '/widgets/new' }
+      end
+
+      context 'calling a main app url helper with arguments' do
+        subject { helper.widget_path(mock_model(Widget, id: 123)) }
+        it { should == '/widgets/123' }
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Make the arguments nil if they are empty, so rails doesn't think we're passing arguments to be appended to the query string in the url helper.

https://www.pivotaltracker.com/story/show/26331775
