### PR TITLE
[Ethan] [Fixes #26460959] Duplicate request key bug

### DIFF
--- a/app/helpers/tandem/pages_helper.rb
+++ b/app/helpers/tandem/pages_helper.rb
@@ -228,7 +228,9 @@ module Tandem
       end
 
       def request_key
-        "#{controller_path}-#{action_name}".gsub(/[^\w]|_/, '-')
+        key = "#{controller_path}-#{action_name}".gsub(/[^\w]|_/, '-')
+        key += "-#{params[:id]}" if key == 'tandem-pages-show'
+        key
       end
 
       def using_tandem_abilities

--- a/spec/helpers/tandem/pages_helper_spec.rb
+++ b/spec/helpers/tandem/pages_helper_spec.rb
@@ -251,13 +251,25 @@ module Tandem
     describe '#request_key' do
       context "from tandem/pages#home" do
         before(:each) do
-          helper.stub(:controller_path) { 'tandem_pages' }
+          helper.stub(:controller_path) { 'tandem/pages' }
           helper.stub(:action_name) { 'home' }
         end
 
         subject { helper.send(:request_key) }
 
         it { should == 'tandem-pages-home' }
+      end
+
+      context "from tandem/pages#show" do
+        before(:each) do
+          helper.stub(:controller_path) { 'tandem/pages' }
+          helper.stub(:action_name) { 'show' }
+          helper.stub(:params) { { id: 'bamboo' } }
+        end
+
+        subject { helper.send(:request_key) }
+
+        it { should == 'tandem-pages-show-bamboo' }
       end
     end
   end


### PR DESCRIPTION
If the request containing a tandem content is tandem-pages-show, then append the id, so tandem pages can have unique content. Kind of important. :)

https://www.pivotaltracker.com/story/show/26460959
