### PR TITLE
[Fixes #26588459] authorize the pages#home action based on if the user can :show instead of :index Page

### DIFF
--- a/app/controllers/tandem/pages_controller.rb
+++ b/app/controllers/tandem/pages_controller.rb
@@ -7,7 +7,7 @@ module Tandem
     # GET /pages.home.json
     def home
       @page = Page.where(is_default: true).first || Page.first || create_default_page
-      authorize!(:index, Page)
+      authorize!(:show, Page)
       respond_to do |format|
         format.html { render (@page.template.present? ? @page.template : 'show'), notice: @page.new_record? ? 'No Pages Found.' : '' }
         format.json { render json: @page }


### PR DESCRIPTION
It makes more sense and allows main app developers the ability to not
allow indexing Page, without also removing access to the home page.

https://www.pivotaltracker.com/story/show/26588459
