### PR TITLE
[Colleen] Css fixes

### DIFF
--- a/app/assets/stylesheets/tandem/contents.scss
+++ b/app/assets/stylesheets/tandem/contents.scss
@@ -364,7 +364,7 @@ section#tandem_image_gallery {
          transform: rotate(0deg) scale(1.05);
          z-index: 300;
         }
-        
+      }  
     }
 
   }

--- a/app/assets/stylesheets/tandem/contents.scss
+++ b/app/assets/stylesheets/tandem/contents.scss
@@ -9,6 +9,7 @@ body.tandem-admin-bar {
   margin-top: 35px;
 }
 #tandem_page_links {
+body #tandem_page_links {
   z-index: 900;
   position: fixed;
   top: 0;
@@ -26,6 +27,7 @@ body.tandem-admin-bar {
     a, a:active, a:visited {
      color: $lightblue;
      text-decoration: none; 
+     @include goo;
      &:hover {color: #aaa;}
     }
   }

--- a/app/assets/stylesheets/tandem/scaffold.scss
+++ b/app/assets/stylesheets/tandem/scaffold.scss
@@ -51,6 +51,27 @@
     font-size: 12px;
     list-style: square;
   }
+  p#tandem-new {
+   padding: 10px 0;
+   a, a:visited, a:active {
+     @include goo;
+     background: $lightblue;
+     padding: 5px 8px;
+     color: $darkblue;
+     @include radius(5px);
+     text-decoration: none;
+     border: 1px solid $darkblue;
+     &:hover {
+       background: $darkblue;
+       color: $lightblue;
+       border-color: $lightblue;
+     }
+   } 
+   
+  }
+  table {
+    margin: 10px 0;
+  }
 } 
 
 // end tandem show page styles

--- a/app/assets/stylesheets/tandem/scaffold.scss
+++ b/app/assets/stylesheets/tandem/scaffold.scss
@@ -7,7 +7,6 @@
 #tandem-defaults { 
   width: 940px;
   margin: 0 auto;
-  @include goo;
   color: #333; 
   padding: 15px;
   .hero h1 {

--- a/app/views/tandem/pages/index.html.slim
+++ b/app/views/tandem/pages/index.html.slim
@@ -1,6 +1,8 @@
 #tandem-defaults
 	h1.tandem-title Pages Listing
-
+	- if can?(:create, ::Tandem::Page)
+	  p#tandem-new
+	    = link_to 'Create a New Page', tandem.new_page_path, :class => :page_link, :id => :page_new_link
 	table
 	  tr
 	    th Parent
@@ -29,7 +31,6 @@
 	      - if can?(:destroy, page)
 	        td= link_to 'Delete', tandem.page_path(page), :confirm => 'Are you sure?', :method => :delete
 
-	br
 
-	- if can?(:create, ::Tandem::Page)
-	  = link_to 'New Page', tandem.new_page_path, :class => :page_link, :id => :page_new_link
+
+


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/28118513
- Fixed it so that Tandem fonts won't be overwritten by 'body' font
- Also added styling to the 'new page' button on /pages, and took off tandem fonts so that page can be styled to fit the app that's using Tandem
