### PR TITLE
[Ethan] [Fixes #33093337, fixes #58] Since url_helper's arguments are passed in ...

### DIFF
--- a/History.rdoc
+++ b/History.rdoc
@@ -1,3 +1,6 @@
+0.3 - TBD
+ * Bug - Options passed to a main_app url_helper from within tandem get passed as an array
+
 0.2.2 - June 28, 2012
  * Bug - Bundled tandem-specific fonts instead of using Google's fonts so that it doesn't throw warnings if using https protocol.
 

--- a/app/helpers/tandem/application_helper.rb
+++ b/app/helpers/tandem/application_helper.rb
@@ -3,8 +3,8 @@ module Tandem
     def self.included(base)
       main_app_url_helpers.each do |helper|
         base.send(:define_method, helper) do |*arguments|
-          arguments = nil if arguments.empty?
-          main_app.send(helper, arguments)
+          arguments = [{}] if arguments.empty?
+          main_app.send(helper, *arguments)
         end
       end
     end

--- a/spec/helpers/tandem/application_helper_spec.rb
+++ b/spec/helpers/tandem/application_helper_spec.rb
@@ -27,6 +27,11 @@ module Tandem
         subject { helper.widget_path(mock_model(Widget, id: 123)) }
         it { should == '/widgets/123' }
       end
+
+      context 'calling a main app url helper with the optional options hash' do
+        subject { helper.widgets_path(format: :json) }
+        it { should == '/widgets.json' }
+      end
     end
 
   end


### PR DESCRIPTION
...as an array, splat the array when sending it to the main_app's url_helper
