### PR TITLE
[Trey] CSS Specificity

### DIFF
--- a/app/assets/stylesheets/tandem.css
+++ b/app/assets/stylesheets/tandem.css
@@ -3,5 +3,8 @@
  * and any sub-directories. You're free to add application-wide styles to this file and they'll appear at
  * the top of the compiled file, but it's generally better to create a new file per style scope.
  *= require_self
- *= require_tree './tandem'
+ *= require tandem/colorbox
+ *= require tandem/variables
+ *= require tandem/contents
+ *= require tandem/scaffold
 */

--- a/app/assets/stylesheets/tandem/colorbox.css.erb
+++ b/app/assets/stylesheets/tandem/colorbox.css.erb
@@ -3,7 +3,10 @@
     ColorBox Core Style:
     The following CSS is consistent between example themes and should not be altered.
 */
-#colorbox, #cboxOverlay, #cboxWrapper{position:absolute; top:0; left:0; z-index:9999; overflow:hidden;}
+#colorbox, #cboxOverlay, #cboxWrapper{position:absolute; top:0; left:0; z-index:9999; overflow:hidden;
+-moz-box-sizing: content-box;
+-webkit-box-sizing: content-box;
+box-sizing: content-box;}
 #cboxOverlay{position:fixed; width:100%; height:100%;}
 #cboxMiddleLeft, #cboxBottomLeft{clear:left;}
 #cboxContent{position:relative;}

--- a/app/assets/stylesheets/tandem/contents.scss
+++ b/app/assets/stylesheets/tandem/contents.scss
@@ -174,6 +174,10 @@ h4.tandem-logo {
       border: none;
       text-transform: inherit;
     }
+    input[type="checkbox"], input[type="radio"] {
+      position: relative;
+      bottom: 5px;
+    }
     textarea {
       font-family: Times New Roman, serif;
     }
@@ -195,7 +199,7 @@ h4.tandem-logo {
       color: $darkblue;
       padding: 0 10px 0 5px;
       position: relative;
-      top: 0;
+      top: -5px;
     }
    .wym_box {
      background: none;

--- a/app/assets/stylesheets/tandem/contents.scss
+++ b/app/assets/stylesheets/tandem/contents.scss
@@ -520,9 +520,12 @@ section#tandem_image_gallery {
   font-size: 13px;
   bottom: 25px;
 }
+#cboxContent {
+ background: #fff url(image_path('tandem/tandem_logo.png')) 0 100%  no-repeat; 
+}
 #cboxLoadedContent{
   padding-bottom: 50px;
-  background: transparent url(image_path('tandem/tandem_logo.png')) 0 100%  no-repeat;
+  background: #fff;
 
 }
 

--- a/app/assets/stylesheets/tandem/contents.scss
+++ b/app/assets/stylesheets/tandem/contents.scss
@@ -172,6 +172,10 @@ h4.tandem-logo {
       color: #333;
       @include sans-serif;
       border: none;
+      text-transform: inherit;
+    }
+    textarea {
+      font-family: Times New Roman, serif;
     }
     select {
       width: auto;

--- a/app/assets/stylesheets/tandem/contents.scss
+++ b/app/assets/stylesheets/tandem/contents.scss
@@ -90,8 +90,7 @@ h4.tandem-logo {
 
 /////// Contents, Page, & Image Editor
 
-#tandem-editor {
-  // width: 600px;
+#tandem-editor {  
   width: 100%;
   
 }

--- a/app/assets/stylesheets/tandem/contents.scss
+++ b/app/assets/stylesheets/tandem/contents.scss
@@ -26,12 +26,15 @@ body.tandem-admin-bar {
     a, a:active, a:visited {
      color: $lightblue;
      text-decoration: none; 
-     &:hover {color: #aaa;}
+     @include goo;
+     &:hover {color: #aaa;@include goo;}
+
     }
   }
   a#page_new_link {
     background: transparent url(image_path('tandem/tandem_logo_nav.png')) left no-repeat;
     padding-left: 100px;
+    @include goo;
   }
 }
 .tandem_content:hover {
@@ -88,26 +91,35 @@ h4.tandem-logo {
 /////// Contents, Page, & Image Editor
 
 #tandem-editor {
-  width: 600px;
+  // width: 600px;
+  width: 100%;
+  
 }
 #tandem-editor-wym {
   width: 100%;
 }
 
 #tandem-editor, #tandem-editor-wym {
-  h1.tandem-title {
-    font-size: 18px;
-    @include goo;
+  h1, h1.tandem-title {    
+    @include sans-serif;
+    font-size: 20px;
     color: $darkblue;
-    font-weight: none;
-    margin: 10px 0;
+    font-weight: 300 !important;
+    margin: 0 0 5px 0;
+    padding: 0 0 5px 0;
+    background: none;
+    line-height: normal;  
+    border: none;
+    border-bottom: 1px solid $lightblue;
+    background: none;  
   }
   h3#selected_image_title {
-    font-size: 20px;
     @include goo;
-    color: #407992;
-    font-weight: normal;
+    font-size: 20px;
+    color: #407992;    
     margin: 15px 0;
+    padding: 0;
+    border: none;
   }
   iframe{
     border:none;
@@ -119,6 +131,8 @@ h4.tandem-logo {
     color: $darkblue;
   }
   form {
+    margin: 0;
+    padding: 0;    
     div {
       padding: 5px;
     }
@@ -130,34 +144,54 @@ h4.tandem-logo {
       }
     }
     label {
-      @include goo;
+      @include goo;      
+      font-size: 15px !important;
       color: $darkblue;
       width: 100px;
-      padding: 0;
+      height: 100%;
+      padding: 3px 0 0 0;
+      margin:0;
+      line-height: normal;
       text-align: left;
-      font-size: 14px;
-      margin-left: 10px;  
+      font-size: 14px;        
       display:block;
-      float: left;
+      float: left;      
+      border: none;
+
     }
     input, textarea {
       border: 1px solid #ccc;
       @include radius(3px);
+      -webkit-box-shadow: 0 0 5px #aaa;
+      -moz-box-shadow: 0 0 5px #aaa;
       box-shadow: 0 0 5px #aaa;
       padding: 5px;
       position:relative;
+      width: auto;
+      background: white;
+      color: #333;
+      @include sans-serif;
+      border: none;
     }
-    input#page_is_default, input#page_parent_id_, input#page_parent_id_1 {top:5px;}
+    select {
+      width: auto;
+      @include sans-serif;      
+    }
+    input#page_is_default, input#page_parent_id_, input#page_parent_id_1 {      
+      margin-right: 0;
+      vertical-align: none;
+    }
     .field {
       margin: 15px 0;
       @include goo;
+      width: auto;
     }
     .field span {
       font-size: 14px;
       color: $darkblue;
       padding: 0 10px 0 5px;
       position: relative;
-      top: 5px;
+      top: 0;
     }
    .wym_box {
      background: none;

--- a/app/assets/stylesheets/tandem/variables.scss
+++ b/app/assets/stylesheets/tandem/variables.scss
@@ -4,6 +4,17 @@
 
 @mixin goo {
   font-family: 'Glegoo', serif;
+  font-weight: 300;
+  text-transform: inherit;
+  font-size: 15px;
+  font-style: normal;
+}
+@mixin sans-serif {
+  font-family: 'Helvetica Neue', Helvetica, sans-serif;
+  font-weight: 300;
+  font-size: 15px;
+  text-transform: capitalize;
+  font-style: normal;
 }
 
 @mixin radius($radius) {


### PR DESCRIPTION
Here's the initial pull request for fixing any UI display issues with Tandem
- Initializes content-box on all Tandem UI elements (gets rid of the conflict we were seeing with Kickstand)
- Keeps Tandem sizing/fonts/colors from being replaced by website fonts
