### PR TITLE
[Drew] [#31830409] Fix tandem generator css bug

### DIFF
--- a/lib/generators/tandem_generator.rb
+++ b/lib/generators/tandem_generator.rb
@@ -21,6 +21,6 @@ class TandemGenerator < Rails::Generators::Base
 
   def inject_tandem_assets
     append_to_file 'app/assets/javascripts/application.js', '//= require tandem'
-    insert_into_file 'app/assets/stylesheets/application.css', " *= require tandem\n", :before => /^\*\/$/
+    insert_into_file 'app/assets/stylesheets/application.css', " *= require tandem\n", :before => /^\s?\*\/$/
   end
 end


### PR DESCRIPTION
Fix bug that prevented the tandem generator from adding tandem.css to the application's stylesheet manifest

Rails started including a space before the end comment. Made the space
optional to be backwards compatible with previous versions of rails
where there isn't a space.
