### PR TITLE
[Trey?] Wymeditor embed plugin

### DIFF
--- a/app/assets/javascripts/tandem.js
+++ b/app/assets/javascripts/tandem.js
@@ -9,6 +9,7 @@
 //= require tandem/modernizr-2.5.3.min
 //= require tandem/jquery.colorbox
 //= require tandem/wymeditor/jquery.wymeditor.min
+//= require tandem/wymeditor/plugins/embed/jquery.wymeditor.embed.js
 //= require tandem/jquery.ui.widget
 //= require tandem/jquery-fileupload
 //= require tandem/pages


### PR DESCRIPTION
I added a line to tandem.js to include the wymeditor embed plugin that was sitting in the vendor folder. The editor strips iframe tags by default, and this plugin allows Youtube and Vimeo videos to be embedded. I am using this for the MHW help page, and figured it could be merged into tandem master.
