### PR TITLE
fix "marshal data too short" error when running bundle install for the first time

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 # Declare your gem's dependencies in tandem.gemspec.
 # Bundler will treat runtime dependencies like base dependencies, and

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       slim-rails
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     actionmailer (3.2.8)
       actionpack (= 3.2.8)


### PR DESCRIPTION
When running "bundle install" for the first time bundler crashed and displayed this error "marshal data too short". I found a bundler issue that referenced the error and recommended changing the ruby gems url from http to https (bundler/bundler#2015). Once the initial install is done it did not matter if the url was http or https. But I was able to reproduce by creating a new gemset with rvm and running "bundle install" again.
